### PR TITLE
Update to .NET 9, package updates

### DIFF
--- a/src/Microsoft.eShopWeb.Web/Microsoft.eShopWeb.Web.fsproj
+++ b/src/Microsoft.eShopWeb.Web/Microsoft.eShopWeb.Web.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Domain.fs" />
@@ -24,6 +24,6 @@
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.FSharp" Version="6.0.7" />
     <PackageReference Include="Falco" Version="4.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the project to target .NET 9.0 and upgrades the version of `Microsoft.EntityFrameworkCore.Sqlite` to ensure compatibility with the new framework version.

Framework upgrade:

* [`src/Microsoft.eShopWeb.Web/Microsoft.eShopWeb.Web.fsproj`](diffhunk://#diff-97310aae4e77281857fd8373eddc2cd9ed72bab7b35a9130ff6d44fcfe699fb3L3-R3): Changed the `TargetFramework` property from `net8.0` to `net9.0`.

Dependency update:

* [`src/Microsoft.eShopWeb.Web/Microsoft.eShopWeb.Web.fsproj`](diffhunk://#diff-97310aae4e77281857fd8373eddc2cd9ed72bab7b35a9130ff6d44fcfe699fb3L27-R27): Updated the `Microsoft.EntityFrameworkCore.Sqlite` package reference from version `8.0.0` to `9.0.6`.